### PR TITLE
Added rule to parse "tom" as "tomorrow"

### DIFF
--- a/src/parsers/EN/ENCasualDateParser.js
+++ b/src/parsers/EN/ENCasualDateParser.js
@@ -34,7 +34,7 @@ exports.Parser = function ENCasualDateParser(){
             result.start.imply('hour', 22);
             result.start.imply('meridiem', 1);
 
-        } else if(lowerText == 'tomorrow' || lowerText == 'tmr'){
+        } else if(lowerText == 'tomorrow' || lowerText == 'tmr' || lowerText == 'tom'){
 
             // Check not "Tomorrow" on late night
             if(refMoment.hour() > 4) {


### PR DESCRIPTION
Fairly simple change. Ran the test suite as recommended in the docs before and after making my change, and they all passed both times. Not sure if it's bad form to have three or-conditions like this, but if so, I'd just as soon replace `tmr` with `tom` -- the former hardly seems as intuitive as the latter.